### PR TITLE
Changed url to point to new location of qhull repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "qhull"]
 	path = qhull
-	url = git://gitorious.org/qhull/qhull.git
+	url = git://github.com/qhull/qhull.git
 [submodule "docsys"]
 	path = docsys
 	url = git@github.com:niftools/nifdocsys.git


### PR DESCRIPTION
Gitorious no longer exists since 2015; qhull is now hosted on GitHub.