### PR TITLE
Added explicit Niflib:: to unprefixed instances of array<>

### DIFF
--- a/include/gen/ArkTexture.h
+++ b/include/gen/ArkTexture.h
@@ -36,7 +36,7 @@ struct ArkTexture {
 	/*! Unknown. */
 	Ref<NiTexturingProperty > texturingProperty;
 	/*! Unknown. */
-	array<9,byte > unknownBytes;
+	Niflib::array<9,byte > unknownBytes;
 	//--BEGIN MISC CUSTOM CODE--//
 	//--END CUSTOM CODE--//
 };

--- a/include/gen/BSTreadTransfInfo.h
+++ b/include/gen/BSTreadTransfInfo.h
@@ -28,7 +28,7 @@ struct BSTreadTransfInfo {
 	/*! Unknown Flag */
 	float unknownFloat1;
 	/*! Data */
-	array<2,BSTreadTransfSubInfo > data;
+	Niflib::array<2,BSTreadTransfSubInfo > data;
 	//--BEGIN MISC CUSTOM CODE--//
 	//--END CUSTOM CODE--//
 };

--- a/include/gen/BoxBV.h
+++ b/include/gen/BoxBV.h
@@ -26,9 +26,9 @@ struct BoxBV {
 	/*! Center */
 	Vector3 center;
 	/*! Axis */
-	array<3,Vector3 > axis;
+	Niflib::array<3,Vector3 > axis;
 	/*! Extent */
-	array<3,float > extent;
+	Niflib::array<3,float > extent;
 	//--BEGIN MISC CUSTOM CODE--//
 	//--END CUSTOM CODE--//
 };

--- a/include/gen/ExtraMeshDataEpicMickey2.h
+++ b/include/gen/ExtraMeshDataEpicMickey2.h
@@ -28,7 +28,7 @@ struct ExtraMeshDataEpicMickey2 {
 	/*! Unknown. */
 	int end;
 	/*! Unknown. */
-	array<10,short > unknownShorts;
+	Niflib::array<10,short > unknownShorts;
 	//--BEGIN MISC CUSTOM CODE--//
 
 	//--END CUSTOM CODE--//

--- a/include/gen/Header.h
+++ b/include/gen/Header.h
@@ -33,7 +33,7 @@ struct Header {
 	 */
 	HeaderString headerString;
 	/*! Unknown. */
-	array<3,LineString > copyright;
+	Niflib::array<3,LineString > copyright;
 	/*!
 	 * The NIF version, in hexadecimal notation: 0x04000002, 0x0401000C, 0x04020002,
 	 * 0x04020100, 0x04020200, 0x0A000100, 0x0A010000, 0x0A020000, 0x14000004, ...

--- a/include/gen/LODRange.h
+++ b/include/gen/LODRange.h
@@ -28,7 +28,7 @@ struct LODRange {
 	/*! End of Range. */
 	float farExtent;
 	/*! Unknown (0,0,0). */
-	array<3,unsigned int > unknownInts;
+	Niflib::array<3,unsigned int > unknownInts;
 	//--BEGIN MISC CUSTOM CODE--//
 	//--END CUSTOM CODE--//
 };

--- a/include/gen/ParticleDesc.h
+++ b/include/gen/ParticleDesc.h
@@ -26,7 +26,7 @@ struct ParticleDesc {
 	/*! Unknown. */
 	Vector3 translation;
 	/*! Unknown. */
-	array<3,float > unknownFloats1;
+	Niflib::array<3,float > unknownFloats1;
 	/*! Unknown. */
 	float unknownFloat1;
 	/*! Unknown. */

--- a/include/gen/SkinData.h
+++ b/include/gen/SkinData.h
@@ -36,7 +36,7 @@ struct SkinData {
 	/*! Radius for bounding sphere holding all vertices. */
 	float boundingSphereRadius;
 	/*! Unknown, always 0? */
-	array<13,short > unknown13Shorts;
+	Niflib::array<13,short > unknown13Shorts;
 	/*! Number of weighted vertices. */
 	mutable unsigned short numVertices;
 	/*! The vertex weights. */

--- a/include/obj/ATextureRenderData.h
+++ b/include/obj/ATextureRenderData.h
@@ -77,14 +77,14 @@ protected:
 	/*! Bits per pixel, 0 (?), 8, 24 or 32. */
 	byte bitsPerPixel;
 	/*! Zero? */
-	array<3,byte > unknown3Bytes;
+	Niflib::array<3,byte > unknown3Bytes;
 	/*!
 	 * [96,8,130,0,0,65,0,0] if 24 bits per pixel
 	 *             [129,8,130,32,0,65,12,0] if 32 bits per pixel
 	 *             [34,0,0,0,0,0,0,0] if 8 bits per pixel
 	 *             [4,0,0,0,0,0,0,0] if 0 (?) bits per pixel
 	 */
-	array<8,byte > unknown8Bytes;
+	Niflib::array<8,byte > unknown8Bytes;
 	/*! Seems to always be zero. */
 	unsigned int unknownInt;
 	/*! Unknown.  Could be reference pointer. */
@@ -98,7 +98,7 @@ protected:
 	/*! Unknown. */
 	byte unknownByte1;
 	/*! Channel Data */
-	array<4,ChannelData > channels;
+	Niflib::array<4,ChannelData > channels;
 	/*! Link to NiPalette, for 8-bit textures. */
 	Ref<NiPalette > palette;
 	/*! Number of mipmaps in the texture. */

--- a/include/obj/BSPSysSimpleColorModifier.h
+++ b/include/obj/BSPSysSimpleColorModifier.h
@@ -70,7 +70,7 @@ protected:
 	/*! Unknown */
 	float color2StartPercent;
 	/*! Colors */
-	array<3,Color4 > colors;
+	Niflib::array<3,Color4 > colors;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/CStreamableAssetData.h
+++ b/include/obj/CStreamableAssetData.h
@@ -65,7 +65,7 @@ protected:
 	/*! Unknown. */
 	Ref<NiNode > root;
 	/*! Unknown. */
-	array<5,byte > unknownBytes;
+	Niflib::array<5,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/FxWidget.h
+++ b/include/obj/FxWidget.h
@@ -58,7 +58,7 @@ protected:
 	/*! Unknown. */
 	byte unknown3;
 	/*! Looks like 9 links and some string data. */
-	array<292,byte > unknown292Bytes;
+	Niflib::array<292,byte > unknown292Bytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/Ni3dsAlphaAnimator.h
+++ b/include/obj/Ni3dsAlphaAnimator.h
@@ -63,7 +63,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<40,byte > unknown1;
+	Niflib::array<40,byte > unknown1;
 	/*! The parent? */
 	Ref<NiObject > parent;
 	/*! Unknown. */

--- a/include/obj/Ni3dsAnimationNode.h
+++ b/include/obj/Ni3dsAnimationNode.h
@@ -67,17 +67,17 @@ protected:
 	/*! Unknown. */
 	bool hasData;
 	/*! Unknown. Matrix? */
-	array<21,float > unknownFloats1;
+	Niflib::array<21,float > unknownFloats1;
 	/*! Unknown. */
 	unsigned short unknownShort;
 	/*! Child? */
 	Ref<NiObject > child;
 	/*! Unknown. */
-	array<12,float > unknownFloats2;
+	Niflib::array<12,float > unknownFloats2;
 	/*! A count. */
 	mutable unsigned int count;
 	/*! Unknown. */
-	vector< array<5,byte > > unknownArray;
+	vector< Niflib::array<5,byte > > unknownArray;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/Ni3dsColorAnimator.h
+++ b/include/obj/Ni3dsColorAnimator.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<184,byte > unknown1;
+	Niflib::array<184,byte > unknown1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/Ni3dsMorphShape.h
+++ b/include/obj/Ni3dsMorphShape.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<14,byte > unknown1;
+	Niflib::array<14,byte > unknown1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/Ni3dsParticleSystem.h
+++ b/include/obj/Ni3dsParticleSystem.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<14,byte > unknown1;
+	Niflib::array<14,byte > unknown1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/Ni3dsPathController.h
+++ b/include/obj/Ni3dsPathController.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<20,byte > unknown1;
+	Niflib::array<20,byte > unknown1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiAVObject.h
+++ b/include/obj/NiAVObject.h
@@ -284,7 +284,7 @@ protected:
 	/*! List of node properties. */
 	vector<Ref<NiProperty > > properties;
 	/*! Always 2,0,2,0. */
-	array<4,unsigned int > unknown1;
+	Niflib::array<4,unsigned int > unknown1;
 	/*! 0 or 1. */
 	byte unknown2;
 	/*! Do we have a bounding box? */

--- a/include/obj/NiArkAnimationExtraData.h
+++ b/include/obj/NiArkAnimationExtraData.h
@@ -58,9 +58,9 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<4,int > unknownInts;
+	Niflib::array<4,int > unknownInts;
 	/*! Unknown. */
-	array<37,byte > unknownBytes;
+	Niflib::array<37,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiArkImporterExtraData.h
+++ b/include/obj/NiArkImporterExtraData.h
@@ -64,9 +64,9 @@ protected:
 	/*! Contains a string like "Gamebryo_1_1" or "4.1.0.12" */
 	IndexString importerName;
 	/*! Unknown. */
-	array<13,byte > unknownBytes;
+	Niflib::array<13,byte > unknownBytes;
 	/*! Unknown. */
-	array<7,float > unknownFloats;
+	Niflib::array<7,float > unknownFloats;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiArkTextureExtraData.h
+++ b/include/obj/NiArkTextureExtraData.h
@@ -61,7 +61,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<2,int > unknownInts1;
+	Niflib::array<2,int > unknownInts1;
 	/*! Unknown. */
 	byte unknownByte;
 	/*! Unknown. */

--- a/include/obj/NiArkViewportInfoExtraData.h
+++ b/include/obj/NiArkViewportInfoExtraData.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<13,byte > unknownBytes;
+	Niflib::array<13,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiBSplinePoint3Interpolator.h
+++ b/include/obj/NiBSplinePoint3Interpolator.h
@@ -56,7 +56,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<6,float > unknownFloats;
+	Niflib::array<6,float > unknownFloats;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiBezierMesh.h
+++ b/include/obj/NiBezierMesh.h
@@ -77,13 +77,13 @@ protected:
 	/*! Unknown (illegal link?). */
 	unsigned int unknown5;
 	/*! data. */
-	vector< array<2,float > > points2;
+	vector< Niflib::array<2,float > > points2;
 	/*! unknown */
 	unsigned int unknown6;
 	/*! data count 2. */
 	mutable unsigned short count2;
 	/*! data count. */
-	vector< array<4,unsigned short > > data2;
+	vector< Niflib::array<4,unsigned short > > data2;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiBezierTriangle4.h
+++ b/include/obj/NiBezierTriangle4.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! unknown */
-	array<6,unsigned int > unknown1;
+	Niflib::array<6,unsigned int > unknown1;
 	/*! unknown */
 	unsigned short unknown2;
 	/*! unknown */
@@ -68,13 +68,13 @@ protected:
 	/*! unknown */
 	Vector3 vector2;
 	/*! unknown */
-	array<4,short > unknown3;
+	Niflib::array<4,short > unknown3;
 	/*! unknown */
 	byte unknown4;
 	/*! unknown */
 	unsigned int unknown5;
 	/*! unknown */
-	array<24,short > unknown6;
+	Niflib::array<24,short > unknown6;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiBinaryVoxelData.h
+++ b/include/obj/NiBinaryVoxelData.h
@@ -62,9 +62,9 @@ protected:
 	/*! Unknown. Is this^3 the Unknown Bytes 1 size? */
 	unsigned short unknownShort3;
 	/*! Unknown. */
-	array<7,float > unknown7Floats;
+	Niflib::array<7,float > unknown7Floats;
 	/*! Unknown. Always a multiple of 7. */
-	array< 7, array<12,byte > > unknownBytes1;
+	Niflib::array< 7, Niflib::array<12,byte > > unknownBytes1;
 	/*! Unknown. */
 	mutable unsigned int numUnknownVectors;
 	/*! Vectors on the unit sphere. */
@@ -74,7 +74,7 @@ protected:
 	/*! Unknown. */
 	vector<byte > unknownBytes2;
 	/*! Unknown. */
-	array<5,unsigned int > unknown5Ints;
+	Niflib::array<5,unsigned int > unknown5Ints;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiClodData.h
+++ b/include/obj/NiClodData.h
@@ -75,11 +75,11 @@ protected:
 	/*! Unknown. */
 	unsigned short unknownShort;
 	/*! Unknown. */
-	vector< array<6,unsigned short > > unknownClodShorts1;
+	vector< Niflib::array<6,unsigned short > > unknownClodShorts1;
 	/*! Unknown. */
 	vector<unsigned short > unknownClodShorts2;
 	/*! Unknown. */
-	vector< array<6,unsigned short > > unknownClodShorts3;
+	vector< Niflib::array<6,unsigned short > > unknownClodShorts3;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiFloatExtraDataController.h
+++ b/include/obj/NiFloatExtraDataController.h
@@ -60,7 +60,7 @@ protected:
 	/*! Number of extra bytes. */
 	mutable byte numExtraBytes;
 	/*! Unknown. */
-	array<7,byte > unknownBytes;
+	Niflib::array<7,byte > unknownBytes;
 	/*! Unknown. */
 	vector<byte > unknownExtraBytes;
 public:

--- a/include/obj/NiGeometry.h
+++ b/include/obj/NiGeometry.h
@@ -186,13 +186,13 @@ public:
 	 * Returns the array of the only 2 properties that are specific to Bethesda
 	 * \return Returns the array of the 2 properties
 	 */
-   NIFLIB_API array<2,Ref<NiProperty > > GetBSProperties();
+   NIFLIB_API Niflib::array<2,Ref<NiProperty > > GetBSProperties();
 
    /*
 	 * Sets the array of the only 2 properties that are specific to Bethesda
 	 * \param[in] The new array of properties
 	 */
-   NIFLIB_API void SetBSProperties( array<2, Ref<NiProperty> > value);
+   NIFLIB_API void SetBSProperties( Niflib::array<2, Ref<NiProperty> > value);
 
 	//--END CUSTOM CODE--//
 protected:
@@ -221,7 +221,7 @@ protected:
 	/*! Dirty Flag? */
 	bool dirtyFlag;
 	/*! Two property links, used by Bethesda. */
-	array<2,Ref<NiProperty > > bsProperties;
+	Niflib::array<2,Ref<NiProperty > > bsProperties;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiGeometryData.h
+++ b/include/obj/NiGeometryData.h
@@ -309,7 +309,7 @@ protected:
 	 */
 	float radius;
 	/*! Unknown, always 0? */
-	array<13,short > unknown13Shorts;
+	Niflib::array<13,short > unknown13Shorts;
 	/*!
 	 * Do we have vertex colors? These are usually used to fine-tune the lighting of
 	 * the model.

--- a/include/obj/NiKeyframeData.h
+++ b/include/obj/NiKeyframeData.h
@@ -241,7 +241,7 @@ protected:
 	/*! Possibly a vestigial time value?  Doesn't appear to be significant. */
 	float unknownFloat;
 	/*! Individual arrays of keys for rotating X, Y, and Z individually. */
-	array<3,KeyGroup<float > > xyzRotations;
+	Niflib::array<3,KeyGroup<float > > xyzRotations;
 	/*! Translation keys. */
 	KeyGroup<Vector3 > translations;
 	/*! Scale keys. */

--- a/include/obj/NiMultiTextureProperty.h
+++ b/include/obj/NiMultiTextureProperty.h
@@ -69,7 +69,7 @@ protected:
 	 * Describes the various textures used by this mutli-texture property.  Each slot
 	 * probably has special meaning like thoes in NiTexturingProperty.
 	 */
-	array<5,MultiTextureElement > textureElements;
+	Niflib::array<5,MultiTextureElement > textureElements;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiPSParticleSystem.h
+++ b/include/obj/NiPSParticleSystem.h
@@ -105,7 +105,7 @@ protected:
 	/*! Unknown */
 	int unknown21;
 	/*! Unknown */
-	array<4,byte > unknown22;
+	Niflib::array<4,byte > unknown22;
 	/*! Unknown. */
 	int unknown27;
 	/*! Unknown. */

--- a/include/obj/NiPSPlanarCollider.h
+++ b/include/obj/NiPSPlanarCollider.h
@@ -73,7 +73,7 @@ protected:
 	/*! Unknown. */
 	byte unknownByte4;
 	/*! Unknown. */
-	array<8,float > unknownFloats5;
+	Niflib::array<8,float > unknownFloats5;
 	/*! Unknown. */
 	Ref<NiNode > unknownLink6;
 public:

--- a/include/obj/NiPalette.h
+++ b/include/obj/NiPalette.h
@@ -78,7 +78,7 @@ protected:
 	/*! The number of palette entries.  Always = 256. */
 	unsigned int numEntries;
 	/*! The color palette. */
-	array<256,ByteColor4 > palette;
+	Niflib::array<256,ByteColor4 > palette;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiPhysXBodyDesc.h
+++ b/include/obj/NiPhysXBodyDesc.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown */
-	array<136,byte > unknownBytes;
+	Niflib::array<136,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiPhysXD6JointDesc.h
+++ b/include/obj/NiPhysXD6JointDesc.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown */
-	array<388,byte > unknownBytes;
+	Niflib::array<388,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiPhysXKinematicSrc.h
+++ b/include/obj/NiPhysXKinematicSrc.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown */
-	array<6,byte > unknownBytes;
+	Niflib::array<6,byte > unknownBytes;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiPhysXMaterialDesc.h
+++ b/include/obj/NiPhysXMaterialDesc.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown */
-	array<12,unsigned int > unknownInt;
+	Niflib::array<12,unsigned int > unknownInt;
 	/*! Unknown */
 	byte unknownByte1;
 	/*! Unknown */

--- a/include/obj/NiPhysXMeshDesc.h
+++ b/include/obj/NiPhysXMeshDesc.h
@@ -64,13 +64,13 @@ protected:
 	/*! Unknown */
 	short unknownShort2;
 	/*! NXS */
-	array<3,byte > unknownBytes0;
+	Niflib::array<3,byte > unknownBytes0;
 	/*! Unknown */
 	byte unknownByte1;
 	/*! MESH */
-	array<4,byte > unknownBytes1;
+	Niflib::array<4,byte > unknownBytes1;
 	/*! Unknown */
-	array<8,byte > unknownBytes2;
+	Niflib::array<8,byte > unknownBytes2;
 	/*! Unknown */
 	float unknownFloat2;
 	/*! Unknown */
@@ -84,11 +84,11 @@ protected:
 	/*! Vertices */
 	vector<Vector3 > vertices;
 	/*! Unknown */
-	array<982,byte > unknownBytes3;
+	Niflib::array<982,byte > unknownBytes3;
 	/*! Unknown */
-	array<368,short > unknownShorts1;
+	Niflib::array<368,short > unknownShorts1;
 	/*! Unknown */
-	array<3328,unsigned int > unknownInts1;
+	Niflib::array<3328,unsigned int > unknownInts1;
 	/*! Unknown */
 	byte unknownByte2;
 public:

--- a/include/obj/NiTextureModeProperty.h
+++ b/include/obj/NiTextureModeProperty.h
@@ -56,7 +56,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<3,unsigned int > unknownInts;
+	Niflib::array<3,unsigned int > unknownInts;
 	/*! Unknown. Either 210 or 194. */
 	short unknownShort;
 	/*! 0? */

--- a/include/obj/NiTextureProperty.h
+++ b/include/obj/NiTextureProperty.h
@@ -74,13 +74,13 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Property flags. */
-	array<2,unsigned int > unknownInts1;
+	Niflib::array<2,unsigned int > unknownInts1;
 	/*! Property flags. */
 	unsigned short flags;
 	/*! Link to the texture image. */
 	Ref<NiImage > image;
 	/*! Unknown.  0? */
-	array<2,unsigned int > unknownInts2;
+	Niflib::array<2,unsigned int > unknownInts2;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiTransformInterpolator.h
+++ b/include/obj/NiTransformInterpolator.h
@@ -128,7 +128,7 @@ protected:
 	/*! Scale. */
 	float scale;
 	/*! Unknown. */
-	array<3,byte > unknownBytes;
+	Niflib::array<3,byte > unknownBytes;
 	/*! Refers to NiTransformData. */
 	Ref<NiTransformData > data;
 public:

--- a/include/obj/NiTransparentProperty.h
+++ b/include/obj/NiTransparentProperty.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<6,byte > unknown;
+	Niflib::array<6,byte > unknown;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/NiUVData.h
+++ b/include/obj/NiUVData.h
@@ -62,7 +62,7 @@ protected:
 	 * Four UV data groups. Appear to be U translation, V translation, U
 	 * scaling/tiling, V scaling/tiling.
 	 */
-	array<4,KeyGroup<float > > uvGroups;
+	Niflib::array<4,KeyGroup<float > > uvGroups;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/bhkAabbPhantom.h
+++ b/include/obj/bhkAabbPhantom.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<15,int > unknownInts1;
+	Niflib::array<15,int > unknownInts1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/bhkBallAndSocketConstraint.h
+++ b/include/obj/bhkBallAndSocketConstraint.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown */
-	array<4,byte > unknown4Bytes;
+	Niflib::array<4,byte > unknown4Bytes;
 	/*! Unknown */
 	Vector3 unknownFloats1;
 	/*! Unknown */

--- a/include/obj/bhkBoxShape.h
+++ b/include/obj/bhkBoxShape.h
@@ -79,7 +79,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<8,byte > unknown8Bytes;
+	Niflib::array<8,byte > unknown8Bytes;
 	/*! Looks like this could be the box size. */
 	Vector3 dimensions;
 	/*! The smallest of the three sizes. Might be used for optimization. */

--- a/include/obj/bhkBreakableConstraint.h
+++ b/include/obj/bhkBreakableConstraint.h
@@ -60,7 +60,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*!  */
-	array<41,int > unknownInts1;
+	Niflib::array<41,int > unknownInts1;
 	/*! Unknown */
 	short unknownShort1;
 	/*! A count or flag? */

--- a/include/obj/bhkCapsuleShape.h
+++ b/include/obj/bhkCapsuleShape.h
@@ -127,7 +127,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<8,byte > unknown8Bytes;
+	Niflib::array<8,byte > unknown8Bytes;
 	/*! First point on the capsule's axis. */
 	Vector3 firstPoint;
 	/*! Matches first capsule radius. */

--- a/include/obj/bhkCompressedMeshShape.h
+++ b/include/obj/bhkCompressedMeshShape.h
@@ -93,7 +93,7 @@ protected:
 	/*! Unknown. */
 	float unknownFloat1;
 	/*! Unknown. */
-	array<4,byte > unknown4Bytes;
+	Niflib::array<4,byte > unknown4Bytes;
 	/*! Unknown */
 	Vector4 unknownFloats1;
 	/*! A shell with that radius is added around the shape. */

--- a/include/obj/bhkConvexListShape.h
+++ b/include/obj/bhkConvexListShape.h
@@ -104,7 +104,7 @@ protected:
 	/*! The shape's material. */
 	SkyrimHavokMaterial skyrimMaterial;
 	/*! Unknown. Set to (0.0,0.0,-0.0,0.0,0.0,-0.0), where -0.0 is 0x80000000 in hex. */
-	array<6,float > unknownFloats;
+	Niflib::array<6,float > unknownFloats;
 	/*! Unknown Flag */
 	byte unknownByte1;
 	/*! Unknown Flag */

--- a/include/obj/bhkConvexVerticesShape.h
+++ b/include/obj/bhkConvexVerticesShape.h
@@ -127,7 +127,7 @@ protected:
 	 * Unknown. Must be (0.0,0.0,-0.0,0.0,0.0,-0.0) for arrow detection to work (mind
 	 * the minus signs, -0.0 is 0x80000000 in hex).
 	 */
-	array<6,float > unknown6Floats;
+	Niflib::array<6,float > unknown6Floats;
 	/*! Number of vertices. */
 	mutable unsigned int numVertices;
 	/*! Vertices. Fourth component is 0. Lexicographically sorted. */

--- a/include/obj/bhkListShape.h
+++ b/include/obj/bhkListShape.h
@@ -112,7 +112,7 @@ protected:
 	/*! The shape's material. */
 	SkyrimHavokMaterial skyrimMaterial;
 	/*! Unknown. Set to (0.0,0.0,-0.0,0.0,0.0,-0.0), where -0.0 is 0x80000000 in hex. */
-	array<6,float > unknownFloats;
+	Niflib::array<6,float > unknownFloats;
 	/*! Count. */
 	mutable unsigned int numUnknownInts;
 	/*! Unknown. */

--- a/include/obj/bhkMeshShape.h
+++ b/include/obj/bhkMeshShape.h
@@ -63,13 +63,13 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<9,float > unknown1;
+	Niflib::array<9,float > unknown1;
 	/*! Unknown. */
 	mutable int numUnknownFloats;
 	/*! Unknown. */
-	vector< array<3,float > > unknownFloats;
+	vector< Niflib::array<3,float > > unknownFloats;
 	/*! Unknown. */
-	array<3,int > unknown2;
+	Niflib::array<3,int > unknown2;
 	/*! The number of strips data objects referenced. */
 	mutable unsigned int numStripsData;
 	/*! Refers to a bunch of NiTriStripsData objects that make up this shape. */

--- a/include/obj/bhkMoppBvTreeShape.h
+++ b/include/obj/bhkMoppBvTreeShape.h
@@ -159,7 +159,7 @@ protected:
 	/*! The shape's material. */
 	SkyrimHavokMaterial skyrimMaterial;
 	/*! Unknown bytes. */
-	array<8,byte > unknown8Bytes;
+	Niflib::array<8,byte > unknown8Bytes;
 	/*! Unknown float, might be scale. */
 	float unknownFloat;
 	/*! Number of bytes for MOPP data. */

--- a/include/obj/bhkNiTriStripsShape.h
+++ b/include/obj/bhkNiTriStripsShape.h
@@ -152,7 +152,7 @@ protected:
 	/*! Unknown. */
 	unsigned int unknownInt1;
 	/*! Unknown. */
-	array<4,unsigned int > unknownInts1;
+	Niflib::array<4,unsigned int > unknownInts1;
 	/*! Unknown */
 	unsigned int unknownInt2;
 	/*! Scale. Usually (1.0, 1.0, 1.0). */

--- a/include/obj/bhkOrientHingedBodyAction.h
+++ b/include/obj/bhkOrientHingedBodyAction.h
@@ -58,7 +58,7 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<17,int > unknownInts1;
+	Niflib::array<17,int > unknownInts1;
 public:
 	/*! NIFLIB_HIDDEN function.  For internal use only. */
 	NIFLIB_HIDDEN virtual void Read( istream& in, list<unsigned int> & link_stack, const NifInfo & info );

--- a/include/obj/bhkPrismaticConstraint.h
+++ b/include/obj/bhkPrismaticConstraint.h
@@ -58,7 +58,7 @@ protected:
 	/*! Pivot A. */
 	Vector4 pivotA;
 	/*! 4x4 rotation matrix, rotates the child entity. */
-	array<4,Vector4 > rotationMatrixA;
+	Niflib::array<4,Vector4 > rotationMatrixA;
 	/*! Pivot B. */
 	Vector4 pivotB;
 	/*! Describes the axis the object is able to travel along. Unit vector. */

--- a/include/obj/bhkRigidBody.h
+++ b/include/obj/bhkRigidBody.h
@@ -326,12 +326,12 @@ public:
 	 * Returns the unknown 7 shorts
 	 * \return An array containing the 7 unknown shorts within this object.
 	 */
-	NIFLIB_API virtual array<7,unsigned short > GetUnknown7Shorts() const;
+	NIFLIB_API virtual Niflib::array<7,unsigned short > GetUnknown7Shorts() const;
 
 	/*! Replaces the unknown 7 shorts with new data
 	 * \param in An array containing the new data.  Size is 7.
 	 */
-	NIFLIB_API virtual void SetUnknown7Shorts( const array<7,unsigned short > & in );
+	NIFLIB_API virtual void SetUnknown7Shorts( const Niflib::array<7,unsigned short > & in );
 
 
 	//--END CUSTOM CODE--//
@@ -341,7 +341,7 @@ protected:
 	/*! Unknown. */
 	int unknownInt2;
 	/*! Unknown. Could be 3 floats. */
-	array<3,int > unknown3Ints;
+	Niflib::array<3,int > unknown3Ints;
 	/*! The collision response. See hkResponseType for hkpWorld default implementations. */
 	hkResponseType collisionResponse_;
 	/*! Unknown */
@@ -352,7 +352,7 @@ protected:
 	 */
 	unsigned short processContactCallbackDelay_;
 	/*! Unknown. */
-	array<2,unsigned short > unknown2Shorts;
+	Niflib::array<2,unsigned short > unknown2Shorts;
 	/*! Copy of Layer value? */
 	OblivionLayer layerCopy;
 	/*! Copy of Col Filter value? */
@@ -367,7 +367,7 @@ protected:
 	 *             Skyrim defaults: 0 56896 1343 0 0 1 65535 (fourth and fifth element
 	 * *must* be zero)
 	 */
-	array<7,unsigned short > unknown7Shorts;
+	Niflib::array<7,unsigned short > unknown7Shorts;
 	/*!
 	 * A vector that moves the body by the specified amount. Only enabled in
 	 * bhkRigidBodyT objects.

--- a/include/obj/bhkSimpleShapePhantom.h
+++ b/include/obj/bhkSimpleShapePhantom.h
@@ -56,9 +56,9 @@ public:
 	//--END CUSTOM CODE--//
 protected:
 	/*! Unknown. */
-	array<7,float > unkownFloats;
+	Niflib::array<7,float > unkownFloats;
 	/*! Unknown. (1,0,0,0,0) x 3. */
-	array< 3, array<5,float > > unknownFloats2;
+	Niflib::array< 3, Niflib::array<5,float > > unknownFloats2;
 	/*! Unknown. */
 	float unknownFloat;
 public:

--- a/include/obj/bhkTransformShape.h
+++ b/include/obj/bhkTransformShape.h
@@ -116,7 +116,7 @@ protected:
 	/*! Unknown. */
 	float unknownFloat1;
 	/*! Unknown. */
-	array<8,byte > unknown8Bytes;
+	Niflib::array<8,byte > unknown8Bytes;
 	/*! A transform matrix. */
 	Matrix44 transform;
 public:

--- a/src/ComplexShape.cpp
+++ b/src/ComplexShape.cpp
@@ -258,7 +258,7 @@ void ComplexShape::Merge( NiAVObject * root ) {
 		vector<NiPropertyRef> current_property_group =  (*geom)->GetProperties();
 
 		//Special code to handle the Bethesda Skyrim properties
-		array<2, NiPropertyRef> bs_properties = (*geom)->GetBSProperties();
+		Niflib::array<2, NiPropertyRef> bs_properties = (*geom)->GetBSProperties();
 		if(bs_properties[0] != NULL) {
 			current_property_group.push_back(bs_properties[0]);
 		}
@@ -949,7 +949,7 @@ Ref<NiAVObject> ComplexShape::Split( NiNode * parent, Matrix44 & transform, int 
 						alpha_property = DynamicCast<NiAlphaProperty>((*prop));
 					}						
 				}
-				array<2, NiPropertyRef> bs_properties;
+				Niflib::array<2, NiPropertyRef> bs_properties;
 				bs_properties[0] = shader_property;
 				bs_properties[1] = alpha_property;
 				shapes[shape_num]->SetBSProperties(bs_properties);

--- a/src/obj/NiGeometry.cpp
+++ b/src/obj/NiGeometry.cpp
@@ -649,11 +649,11 @@ void NiGeometry::SetBSProperty(short index, Niflib::Ref<NiProperty> value) {
 	}
 }
 
-array<2,Ref<NiProperty > > Niflib::NiGeometry::GetBSProperties() {
+Niflib::array<2,Ref<NiProperty > > Niflib::NiGeometry::GetBSProperties() {
 	return this->bsProperties;
 }
 
-void Niflib::NiGeometry::SetBSProperties( array<2, Ref<NiProperty> > value ) {
+void Niflib::NiGeometry::SetBSProperties( Niflib::array<2, Ref<NiProperty> > value ) {
 	this->bsProperties = value;
 }
 

--- a/src/obj/bhkRigidBody.cpp
+++ b/src/obj/bhkRigidBody.cpp
@@ -569,11 +569,11 @@ void bhkRigidBody::UpdateMassProperties(float density, bool solid, float mass)
 	}
 }
 
-array<7,unsigned short> bhkRigidBody::GetUnknown7Shorts() const {
+Niflib::array<7,unsigned short> bhkRigidBody::GetUnknown7Shorts() const {
 	return unknown7Shorts;
 }
 
-void bhkRigidBody::SetUnknown7Shorts(const array<7,unsigned short> & in ) {
+void bhkRigidBody::SetUnknown7Shorts(const Niflib::array<7,unsigned short> & in ) {
 	unknown7Shorts = in;
 }
 


### PR DESCRIPTION
As of C++11 and later, `std::array<>` is defined in the standard library, causing an ambiguous symbol error when `Niflib::array<>` is referenced without its namespace prefix.